### PR TITLE
Solve stack creation error for blank bucket name

### DIFF
--- a/cloudformation/serverless-web-master.template
+++ b/cloudformation/serverless-web-master.template
@@ -10,7 +10,8 @@
 
 		"HostingBucket": {
 			"Description": "S3 Bucket name for where the website should be hosted",
-			"Type": "String"
+			"Type": "String",
+			"Default": "awslambda-serverless-web-refarch-website"
 		},
 
 		"CodeBucket": {


### PR DESCRIPTION
Summary:
I am very new to all these services.  After reading up a lot on each one I started to follow your instructions to launch the stack.  I noticed that in the aws UI the hosting bucket name was blank, but here was no obvious instruction to fill it out (yes it does indirectly mention it in the second bullet below launch stack but it doesn't make it obvious that it's up to the user to fill it out).  I was a bit surprised and sad when I got the stack creation error.  It wasn't difficult to figure out why it didn't work, but I was surprised to see that this value wasn't defined if it's required for this stack to launch successfully.

I tested this by uploading the file after I modified it and everything worked great!

If there's a reason to not specify this in this file can we update the README or something to make it more clear that it needs to be filled out?  Also thanks for much for creating this example it's very helpful and it's the reason why I am going to use your services to host a web app I'm creating! #Serverless :)

Cheers!
Jake