### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/cloudformation/cognito-creation-helper.template
+++ b/cloudformation/cognito-creation-helper.template
@@ -221,7 +221,7 @@
 						"Type": "AWS::Lambda::Function",
 						"Properties": {
 							"Handler": "index.handler",
-							"Runtime": "nodejs4.3",
+							"Runtime": "nodejs10.x",
 							"Role": { "Fn::GetAtt" : ["LambdaCreateCognitoExecutionRole", "Arn"] },
 							"Code": {
 								"ZipFile": {
@@ -299,7 +299,7 @@
 						"Type": "AWS::Lambda::Function",
 						"Properties": {
 							"Handler": "index.handler",
-							"Runtime": "nodejs4.3",
+							"Runtime": "nodejs10.x",
 							"Role": { "Fn::GetAtt" : ["LambdaUpdateCognitoExecutionRole", "Arn"] },
 							"Code": {
 								"ZipFile": {

--- a/cloudformation/config-helper.template
+++ b/cloudformation/config-helper.template
@@ -56,7 +56,7 @@
             "};"
           ]]}
         },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs10.x",
         "Timeout": "30"
       }
     },

--- a/cloudformation/serverless-web-master.template
+++ b/cloudformation/serverless-web-master.template
@@ -698,7 +698,7 @@
 					"Type": "AWS::Lambda::Function",
 					"Properties": {
 						"Handler": "index.handler",
-						"Runtime": "nodejs4.3",
+						"Runtime": "nodejs10.x",
 						"Role": { "Fn::GetAtt" : ["LambdaToDynamoDBForumTableRole", "Arn"] },
 						"Code": {
 							"ZipFile": {


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-webapp have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.