### PR TITLE
Remove `package-lock.json` from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,6 @@ samconfig.toml
 # node_modules #
 ################
 **/node_modules
-package-lock.json
 packaged.yaml
 
 # OS generated files #


### PR DESCRIPTION
*Issue #, if available:*
No issue created.

*Description of changes:*
This PR removes `package-lock.json` from the `.gitignore` file, allowing the inclusion of the `package-lock.json` file into source control. This is generally seen as best practice for repositories that use NPM. While I don't use yarn, I noticed that the yarn lock file had not been included in the `.gitignore` file so I figured the inclusion of `package-lock.json` may have been a mistake.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
