### PR TITLE
Fix a bug when deleting a TODO item.

### DIFF
--- a/todo-src/deleteTodo/app.js
+++ b/todo-src/deleteTodo/app.js
@@ -45,12 +45,9 @@ function getCognitoUsername(event){
 function deleteRecordById(username, recordId) {
     let params = {
         TableName: TABLE_NAME,
-        KeyConditionExpression: "#username = :username",
-        ExpressionAttributeNames:{
-            "#username": "cognito-username"
-        },
-        ExpressionAttributeValues: {
-            ":username": username
+        Key: {
+            "cognito-username": username,
+            "id": recordId
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Per https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html, Key is required for the DynamoDB DocumentClient delete operation. With this fix, the delete operation fails and the app logs the user out without deleting the record. Moreover, current code doesn't use recordId at all.
